### PR TITLE
API can provide products sorted in categories

### DIFF
--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,8 +1,8 @@
 class Api::CategoriesController < ApplicationController
 
-  def index
-    categories = Category.all
-    render json: { categories: categories }
+  def show
+    category = Category.find_by(title: params["id"])
+    render json: {category: {title: category.title, products: category.products}}
   end
 
 end

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,0 +1,8 @@
+class Api::CategoriesController < ApplicationController
+
+  def index
+    categories = Category.all
+    render json: { categories: categories }
+  end
+
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+    validates_presence_of :title
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
     validates_presence_of :title
+    has_many :products
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ApplicationRecord
     validates_presence_of :title, :ingredients, :price
     validates :price, presence: true, numericality: {only_integer: true, greater_than: 0}
+    belongs_to :category
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,15 @@ module SlowfoodApi
           max_age: 0
       end
     end
+
+    config.generators do |generate|
+      generate.helper false
+      generate.assets false
+      generate.view_specs false
+      generate.helper_specs false
+      generate.routing_specs false
+      generate.controller_specs false
+      generate.request_specs false
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :products, only: [:index]
+    resources :categories, only: [:index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :products, only: [:index]
-    resources :categories, only: [:index]
+    resources :categories, only: [:show]
   end
 end

--- a/db/migrate/20201125180652_create_categories.rb
+++ b/db/migrate/20201125180652_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201126152823_add_association_to_product.rb
+++ b/db/migrate/20201126152823_add_association_to_product.rb
@@ -1,0 +1,7 @@
+class AddAssociationToProduct < ActiveRecord::Migration[6.0]
+  def change
+    change_table :products do |t|
+    t.belongs_to :category, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_180652) do
+ActiveRecord::Schema.define(version: 2020_11_26_152823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,19 +27,9 @@ ActiveRecord::Schema.define(version: 2020_11_25_180652) do
     t.integer "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "category_id", null: false
+    t.index ["category_id"], name: "index_products_on_category_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.boolean "admin", default: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-  end
-
+  add_foreign_key "products", "categories"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_183509) do
+ActiveRecord::Schema.define(version: 2020_11_25_180652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "products", force: :cascade do |t|
     t.string "title"

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "darwin-x64-83",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    title { "MyString" }
+  end
+end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "MyString" }
     ingredients { "MyString" }
     price { 1 }
+    association :category 
   end
 end

--- a/spec/models/categories_spec.rb
+++ b/spec/models/categories_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+RSpec.describe Categories, type: :model do
+  describe "is expected to have db colums" do
+    is {is_expected.to have_db_column :title}
+    is {is_expected.to have_db_column :description}
+  end
+
+  describe "is expected to have validation" do
+    it {is_expected.to validate_presence_of :title}
+  end
+
+  describe "Factory" do
+    it "is expected to be valid" do
+      expect(create(:categorie)).to be_valid
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,8 +1,6 @@
-require 'rails_helper'
-RSpec.describe Categories, type: :model do
+RSpec.describe Category, type: :model do
   describe "is expected to have db colums" do
-    is {is_expected.to have_db_column :title}
-    is {is_expected.to have_db_column :description}
+    it {is_expected.to have_db_column :title}
   end
 
   describe "is expected to have validation" do
@@ -11,7 +9,7 @@ RSpec.describe Categories, type: :model do
 
   describe "Factory" do
     it "is expected to be valid" do
-      expect(create(:categorie)).to be_valid
+      expect(create(:category)).to be_valid
     end
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Category, type: :model do
     it {is_expected.to validate_presence_of :title}
   end
 
+  describe "is expected to have many products" do
+    it {is_expected.to have_many (:products)}
+  end
+
   describe "Factory" do
     it "is expected to be valid" do
       expect(create(:category)).to be_valid

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Product, type: :model do
     it { is_expected.to validate_numericality_of(:price).is_greater_than(0).only_integer }
   end
 
+  describe "is expected to belong to one category" do
+    it {is_expected.to belong_to(:category)}
+  end
 
   describe "Factory" do
     it "is expected to be valid" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
-  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+  config.include Shoulda::Matchers::ActiveRecord, type: :model
   config.include ResponseJSON
 end

--- a/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
+++ b/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe "GET/api/products" do
       get "/api/categories/#{category.title}"
     end
 
-    it "expected to return a 200 response" do
+    it "is expected to return a 200 response" do
       expect(response).to have_http_status 200
     end
   
-    it "expected to return all categories" do
+    it "is expected to return all categories" do
       expect(response_json["category"]["products"].count).to eq 2
+    end
+
+    it "is expected to return the title in category" do
+      expect(response_json["category"]["title"]).to eq "veggie"
+    end
+
+    it "is expected to show title of one of the products" do
+      expect(response_json['category']['products'][1]['title']).to eq 'MyString'
     end
   end
 end

--- a/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
+++ b/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe "GET/api/products" do
+  let!(:categories){3.times{create(:categories)}}
+
+
+  describe "successfully get products sorted in categories" do
+    before do
+      get "/api/categories"
+    end
+
+    it "expected to return a 200 response" do
+      expect(response).to have_http_status 200
+    end
+  
+    it "expected to return all categories" do
+      expect(response_json["categories"].count).to eq 3
+    end
+  end
+end

--- a/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
+++ b/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "GET/api/products" do
-  let!(:categories){3.times{create(:categories)}}
+  let!(:categories){3.times{create(:category)}}
 
 
   describe "successfully get products sorted in categories" do

--- a/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
+++ b/spec/requests/api/api_can_provide_products_sorted_in_categories_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe "GET/api/products" do
-  let!(:categories){3.times{create(:category)}}
+  let!(:category) {create(:category, title: "veggie")}
+  let!(:products) {2.times{create(:product, category: category)}}
 
 
   describe "successfully get products sorted in categories" do
     before do
-      get "/api/categories"
+      get "/api/categories/#{category.title}"
     end
 
     it "expected to return a 200 response" do
@@ -12,7 +13,7 @@ RSpec.describe "GET/api/products" do
     end
   
     it "expected to return all categories" do
-      expect(response_json["categories"].count).to eq 3
+      expect(response_json["category"]["products"].count).to eq 2
     end
   end
 end


### PR DESCRIPTION
[PT-story](https://www.pivotaltracker.com/story/show/175846281)
### User Story
```
As a restaurant API
In order to give the client better sorted products
I would like to be able to send off the products with their category listed 
```
## Changes proposed in this pull request:
* Add Category controller with show action
* Add Category model and Factorybot 
* Add relationship between Product and Category
* Add tests in spec
## What I have learned working on this feature:
* We have learned how to add associations in ActiveRecord between Product and Category
* We have learned writing tests for JSON respose
*We have learned writing tests against instance double 
## Packages/Gems added
* No pacakages/gems
